### PR TITLE
Test infra: pytest migration + tests / lint workflows (#23, #43, #44)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: lint (advisory)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install flake8
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+      - name: Run flake8 (advisory)
+        continue-on-error: true
+        run: flake8 rlm.py tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest numpy pandas
+      - name: Run pytest
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - pip
   - pycodestyle
   - pyflakes
+  - pytest
   - python
   - python-dateutil
   - pytz

--- a/tests/test_rlm.py
+++ b/tests/test_rlm.py
@@ -1,0 +1,28 @@
+"""Pytest entrypoints.
+
+These delegate to the existing TestRLM methods so the bodies don't get
+duplicated during the initial migration. Inlining the bodies as proper
+pytest-idiomatic tests is tracked separately.
+"""
+
+from rlm import TestRLM
+
+
+def test_board_generation_from_piece_list_1():
+    TestRLM().test_board_generation_from_piece_list_1()
+
+
+def test_move_generation_1():
+    TestRLM().test_move_generation_1()
+
+
+def test_move_generation_2():
+    TestRLM().test_move_generation_2()
+
+
+def test_pawn_moves_1():
+    TestRLM().test_pawn_moves_1()
+
+
+def test_entered_move_processing():
+    TestRLM().test_entered_move_processing()


### PR DESCRIPTION
## Summary

Sets up the test infrastructure in three commits so each can be reviewed independently:

1. **`f77b51a` — pytest migration (#23):** adds `tests/test_rlm.py` with one pytest function per `TestRLM` method. Bodies delegate to `TestRLM` for the moment to keep this PR small; inlining as pytest-idiomatic tests is a clean follow-up. Adds `pytest` to `environment.yml` and a minimal `.gitignore`.
2. **`599a9ea` — tests CI workflow (#43):** `.github/workflows/tests.yml`. Runs on PRs to `master` and on push to `master` (post-merge). Installs `pytest numpy pandas` via pip and runs `pytest -v`.
3. **`c75d163` — lint CI workflow (#44):** `.github/workflows/lint.yml`. Runs on every push and every PR (not just master-targeted) so lint issues surface during development. `flake8` is run with `continue-on-error` so findings are visible without blocking merge. Will flip to blocking after #45 (PEP 8 cleanup).

## Test plan

- [x] `pytest -v` locally — 5 passed (with warnings that are tracked elsewhere: tuple-assert fixed by #49, regex escape sequences are #28, `TestRLM` collection warning goes away with the dead-code cleanup).
- [ ] CI green on this PR (will validate once GitHub Actions runs).
- [ ] Confirm lint workflow runs and reports findings without failing the check.

## Notes / known gaps

- The push-trigger on `tests.yml` does not enable direct pushes to master — that's blocked by branch protection. It just runs tests on the merged state of master after a PR lands.
- Required status checks (CI must pass before merge) are intentionally NOT enabled yet — give the workflows a few runs to prove themselves before tightening.
- This PR is based on `master`, so the warning about the tuple-assert pattern will show up in CI output here. PR #49 (already open) fixes that and the warning will be gone once both PRs merge.

Closes #23, #43, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)