### PR TITLE
Small cleanups: dead code, version string, Loudmouth regex (#40, #41, #28)

### DIFF
--- a/rlm.py
+++ b/rlm.py
@@ -4,7 +4,7 @@
 # The python implementation of the Random Legal Move chess-playin', sass talkin', ... thing 
 #
 # 
-versionNumber = 0.40 # basic gameplay is now possible!
+__version__ = "0.40"  # basic gameplay is now possible!
 
 import numpy as np
 import re

--- a/rlm.py
+++ b/rlm.py
@@ -1705,8 +1705,9 @@ class Loudmouth:
         "This {noun} is a {adverb} {adjective} {noun}."
         and inserts random words from the relevant classes.
         '''
-        fill = [x.strip("{}") for x in re.findall('\{.+?\}', template)]
-        template = re.sub("\{.*?\}", "{}", template)
+        slot_pattern = re.compile(r'\{.+?\}')
+        fill = [x.strip("{}") for x in slot_pattern.findall(template)]
+        template = slot_pattern.sub("{}", template)
         self.noggin.squawk_pos()
         print(template.format(*[self.noggin.spew(x) for x in fill]))
 

--- a/rlm.py
+++ b/rlm.py
@@ -1662,29 +1662,6 @@ class Pawn (Piece):
 
 
 
-def sillyDude():
-    dude = random.choice(['Mike', 'Bryan'])
-    print("Is " + dude + " silly?:")
-    def backline():        
-        print(' ' * messagelen, end='')
-        print('\r', end='')
-
-    for __ in range(50):
-        compute = random.random()
-        message = "Computing... " + str(compute)
-        messagelen = len(message)
-        time.sleep(compute/10)
-        print(message, end='')
-        backline()
-    backline()
-    # Put it this way: if silly were a something, and Mike was a something els, he'd be somethinging the first something to some outrageous extent.
-    #mikeThing = 
-    #sillyThing = 
-    #verb = 
-    #extent = 
-    print("Yes. Quite." if compute else "No. Not at all. Why do you ask?")
-
-
 # Prep the dictionary
 class Lexicon:
     def __init__(self, lexfile='subtlex.txt.gz'):
@@ -2005,10 +1982,5 @@ def run_me_if_i_am_the_main_file():
 
 
 
-def run_him_if_i_am_not_the_main_file():
-    print("Interesting; you thought it'd be a good idea to import a random-move-playing chess engine from some other application. How droll!")
-
 if __name__ == '__main__':
     run_me_if_i_am_the_main_file()
-else:
-    run_him_if_i_am_not_the_main_file()


### PR DESCRIPTION
## Summary

Three small, independent fixes that don't conflict with anything else in flight. Each is one commit.

- **`f3cd387` — #40 dead code.** Removed `sillyDude()` and `run_him_if_i_am_not_the_main_file()` + the trailing `else` branch that called it on every import. (Third bullet in #40, `runFromOutside.py`, is already covered by PR #49.)
- **`cd59d8a` — #41 version string.** `versionNumber = 0.40` → `__version__ = "0.40"`. Float versioning has both an equality issue (`0.40 == 0.4`) and an ordering issue (`0.10 < 0.9` as floats). Dunder name is conventional.
- **`2bab115` — #28 Loudmouth regex.** The two regex calls in `Loudmouth.propound` used slightly different patterns (`\{.+?\}` vs `\{.*?\}`). Now compiled once as a raw string and reused — same pattern in both call sites. Side effect: the `\{` invalid-escape SyntaxWarning is gone.

## Test plan

- [x] `TestRLM().run_all_tests()` — all 4 pass.
- [x] `import rlm; rlm.__version__` returns `"0.40"`.
- [x] No more `\{` SyntaxWarning at import. (Tuple-assert SyntaxWarning still present — that's #32, fixed in PR #49.)

## Why these are bundled

All three are independent of the other six open PRs:
- #40 deletes functions in the top-level / `Loudmouth`-adjacent area — not touched by #54/#55/#56 (which are scoped to Board/Move/Player/Game/Piece).
- #41 is a one-line change at the very top of the file.
- #28 is in `Loudmouth.propound`, also outside the #54-56 scope.

No rebase friction expected against any of the existing PRs.

Closes #40, #41, #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)